### PR TITLE
Use hwc buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pcf-dotnet-environment-viewer
 
+## Instructions
 Push the app using manifest defaults, cd into the environment folder that holds the app code:
 ```
 cd ViewEnvironment
@@ -7,7 +8,7 @@ cd ViewEnvironment
 cf push
 ```
 
-Dependencies:
+## Dependencies:
 * [BOSH Release for Windows](https://network.pivotal.io/products/bosh-release-for-windows) on Pivotal Network
 * [Hostable Web Core Buildpack](https://github.com/cloudfoundry-incubator/hwc-buildpack)
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,7 @@ cd ViewEnvironment
 cf push
 ```
 
+Dependencies:
+* [BOSH Release for Windows](https://network.pivotal.io/products/bosh-release-for-windows) on Pivotal Network
+* [Hostable Web Core Buildpack](https://github.com/cloudfoundry-incubator/hwc-buildpack)
 

--- a/ViewEnvironment/manifest.yml
+++ b/ViewEnvironment/manifest.yml
@@ -4,4 +4,4 @@ applications:
   host: env-${random-word}
   memory: 512m
   stack: windows2012R2
-  buildpack: binary_buildpack
+  buildpack: hwc_buildpack


### PR DESCRIPTION
The app no longer deploys as *hwc* has been moved out into its own buildpack. I was able to get it to deploy to a PCF 1.10 environment with Runtime for Windows using the following command:

```
cd ViewEnvironment

cf push -b https://github.com/cloudfoundry-incubator/hwc-buildpack/releases/download/v2.3.3/hwc_buildpack-cached-v2.3.3.zip
```

But to keep the instructions the same, I went ahead and updated the manifest and the README to indicate the buildpack is a prerequisite.